### PR TITLE
Fixed auto encoding of curl does not work

### DIFF
--- a/request.el
+++ b/request.el
@@ -975,7 +975,6 @@ removed from the buffer before it is shown to the parser function.
     (request-log 'debug "Run: %s" (mapconcat 'identity command " "))
     (setf (request-response--buffer response) buffer)
     (process-put proc :request-response response)
-    (set-process-coding-system proc 'binary 'binary)
     (set-process-query-on-exit-flag proc nil)
     (set-process-sentinel proc #'request--curl-callback)
     (when data


### PR DESCRIPTION
https://github.com/abingham/emacs-request/commit/f280319bbab6772013eb9d5703eee305bb8e47f5

curl automatic encoding function does not work.
Previously, there was no problem.
